### PR TITLE
Return promise in initSessionService

### DIFF
--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -14,13 +14,9 @@ describe('API functions', () => {
   const session = { token: '12341234' };
   beforeAll((done) => {
     store = createStore(sessionReducer, initialState);
-
-    // wait for refresh redux store from localStorage
-    const unsubscribe = store.subscribe(() => {
-      unsubscribe();
+    sessionService.initSessionService(store).then( () => {
       done();
-    });
-    sessionService.initSessionService(store);
+    })
   });
 
   describe('refreshFromLocalStorage', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export class sessionService {
 
   static initSessionService(store, options) {
     instance = new sessionService(store, options);
-    sessionService.refreshFromLocalStorage();
+    return sessionService.refreshFromLocalStorage();
   }
 
   static initServerSession(store, req, options) {
@@ -72,7 +72,7 @@ export class sessionService {
     return sessionService.loadSession()
     .then(() => {
       instance.store.dispatch(getSessionSuccess());
-      sessionService.loadUser().then((user) => {
+      return sessionService.loadUser().then((user) => {
         instance.store.dispatch(getUserSessionSuccess(user));
       })
       .catch(() => {


### PR DESCRIPTION
# Changes
* `initSessionService` now returns promise
* `refreshFromLocalStorage` also returns promise `sessionService.loadUser().then(...)` to guarantee that user is set to the redux state when the promise returned by `initSessionService` is resolved.
* `beforeAll` in index.spec.js calls `done` when the promise is resolved, instead of subscribing to redux store.